### PR TITLE
bugfix #245 show in navigation for custom navigation types

### DIFF
--- a/application/zoolu/modules/core/models/Folders.php
+++ b/application/zoolu/modules/core/models/Folders.php
@@ -1425,7 +1425,7 @@ class Model_Folders extends ModelAbstract
 
         if ($intDisplayOptionId > 0) {
             $objSelect1->where('((folderProperties.showInNavigation = ? AND folders.depth = 0) OR (folderProperties.showInNavigation = 1 AND folders.depth > 0))', $intDisplayOptionId)
-                ->where('((pageProperties.showInNavigation = ? AND folders.depth = 0) OR (pageProperties.showInNavigation = 1 AND folders.depth > 0))', $intDisplayOptionId);
+                ->where('((pageProperties.showInNavigation = ? AND folders.depth = 0) OR (pageProperties.showInNavigation = 1 AND folders.depth >= 0))', $intDisplayOptionId);
         } elseif ($intDisplayOptionId != -1) {
             $objSelect1->where('folderProperties.showInNavigation > 0')
                 ->where('pageProperties.showInNavigation > 0');


### PR DESCRIPTION
correct me when i'm false:
`pages without a parentFolder` are loaded over the `$objSelect2`
 and all _other pages_ are loaded through _$objSelect1_. 

Then in the following structure:

page0
folder1
- page12
- page13

folder2
page3

page12, page13 are in the folder1 and folder when has a depth of 0 so in the select it is folders.depth >= 0 and not folders > 0
